### PR TITLE
Interview Editor

### DIFF
--- a/packages/asset/src/components/Editor/Editor.tsx
+++ b/packages/asset/src/components/Editor/Editor.tsx
@@ -84,6 +84,14 @@ export const Editor = (props: EditorProps): JSX.Element => {
       provider.awareness
     );
 
+    const initialLoad = () => {
+      if(props.room === "notes" && type.length === 0) {
+        type.insert(0, "Interview Notes");
+      }
+    };
+
+    provider.on("synced", initialLoad);
+
     // https://github.com/Microsoft/monaco-editor/issues/28#issuecomment-228523529
     window.addEventListener("resize", resize);
     monacoEl.current.addEventListener("resize", resize);
@@ -95,6 +103,7 @@ export const Editor = (props: EditorProps): JSX.Element => {
       editor?.dispose();
       window.removeEventListener("resize", resize);
       monacoEl.current?.removeEventListener("resize", resize);
+      provider.off("synced", initialLoad);
     };
   }, [props]);
 


### PR DESCRIPTION
### What?
This PR adds a header line indicating that the editor is for the Interviewer to take notes. The header line is loaded when the WebSocket synchronization is complete, ensuring the document is initialized correctly.

### Why?
This change improves the user experience by clearly communicating the purpose of the editor, helping users understand that it is intended for taking interview notes.
